### PR TITLE
Support US, NON_US and Custom ShareServer during init

### DIFF
--- a/ShareClient/ShareClient.swift
+++ b/ShareClient/ShareClient.swift
@@ -26,6 +26,12 @@ public enum ShareError: Error {
     case dateError
 }
 
+public enum ShareServer {
+    case US
+    case Non_US
+    case Custom(String)
+}
+
 // From the Dexcom Share iOS app, via @bewest and @shanselman:
 // https://github.com/bewest/share2nightscout-bridge
 private let dexcomUserAgent = "Dexcom Share/3.0.2.11 CFNetwork/711.2.23 Darwin/14.0.0"
@@ -41,22 +47,22 @@ private let maxReauthAttempts = 2
 // ¯\_(ツ)_/¯
 private func dexcomPOST(_ url: URL, JSONData: [String: AnyObject]? = nil, callback: @escaping (Error?, String?) -> Void) {
     var data: Data?
-
+    
     if let JSONData = JSONData {
         guard let encoded = try? JSONSerialization.data(withJSONObject: JSONData, options:[]) else {
             return callback(ShareError.dataError(reason: "Failed to encode JSON for POST to " + url.absoluteString), nil)
         }
-
+        
         data = encoded
     }
-
+    
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     request.addValue("application/json", forHTTPHeaderField: "Content-Type")
     request.addValue("application/json", forHTTPHeaderField: "Accept")
     request.addValue(dexcomUserAgent, forHTTPHeaderField: "User-Agent")
     request.httpBody = data
-
+    
     URLSession.shared.dataTask(with: request, completionHandler: { (data, response, error) in
         if error != nil {
             callback(error, nil)
@@ -69,18 +75,27 @@ private func dexcomPOST(_ url: URL, JSONData: [String: AnyObject]? = nil, callba
 public class ShareClient {
     public let username: String
     public let password: String
-
+    
+    private let shareServer:String?
     private var token: String?
-
-    public init(username: String, password: String) {
+    
+    public init(username: String, password: String, shareServer:ShareServer=ShareServer.US) {
         self.username = username
         self.password = password
+        switch shareServer {
+        case .US:
+            self.shareServer=dexcomServerUS
+        case .Non_US:
+            self.shareServer=dexcomServerNonUS
+        case .Custom(let url):
+            self.shareServer=url
+        }
     }
 
     public func fetchLast(_ n: Int, callback: @escaping (ShareError?, [ShareGlucose]?) -> Void) {
         fetchLastWithRetries(n, remaining: maxReauthAttempts, callback: callback)
     }
-
+    
     private func ensureToken(_ callback: @escaping (ShareError?) -> Void) {
         if token != nil {
             callback(nil)
@@ -95,30 +110,30 @@ public class ShareClient {
             }
         }
     }
-
+    
     private func fetchToken(_ callback: @escaping (ShareError?, String?) -> Void) {
         let data = [
             "accountName": username,
             "password": password,
             "applicationId": dexcomApplicationId
         ]
-
-        guard let url = URL(string: dexcomServerUS + dexcomLoginPath) else {
+        
+        guard let url = URL(string: shareServer! + dexcomLoginPath) else {
             return callback(ShareError.fetchError, nil)
         }
-
+        
         dexcomPOST(url, JSONData: data as [String : AnyObject]?) { (error, response) in
             if let error = error {
                 return callback(.httpError(error), nil)
             }
-
+            
             guard let   response = response,
                 let data = response.data(using: .utf8),
                 let decoded = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)
                 else {
                     return callback(.loginError(errorCode: "unknown"), nil)
             }
-
+            
             if let token = decoded as? String {
                 // success is a JSON-encoded string containing the token
                 callback(nil, token)
@@ -129,37 +144,37 @@ public class ShareClient {
             }
         }
     }
-
+    
     private func fetchLastWithRetries(_ n: Int, remaining: Int, callback: @escaping (ShareError?, [ShareGlucose]?) -> Void) {
         ensureToken() { (error) in
             guard error == nil else {
                 return callback(error, nil)
             }
-
-            guard var components = URLComponents(string: dexcomServerUS + dexcomLatestGlucosePath) else {
+            
+            guard var components = URLComponents(string: self.shareServer! + dexcomLatestGlucosePath) else {
                 return callback(.fetchError, nil)
             }
-
+            
             components.queryItems = [
                 URLQueryItem(name: "sessionId", value: self.token),
                 URLQueryItem(name: "minutes", value: String(1440)),
                 URLQueryItem(name: "maxCount", value: String(n))
             ]
-
+            
             guard let url = components.url else {
                 return callback(.fetchError, nil)
             }
-
+            
             dexcomPOST(url) { (error, response) in
                 if let error = error {
                     return callback(.httpError(error), nil)
                 }
-
+                
                 do {
                     guard let response = response else {
                         throw ShareError.fetchError
                     }
-
+                    
                     let decoded = try? JSONSerialization.jsonObject(with: response.data(using: .utf8)!, options: [])
                     guard let sgvs = decoded as? Array<AnyObject> else {
                         if remaining > 0 {
@@ -169,7 +184,7 @@ public class ShareClient {
                             throw ShareError.dataError(reason: "Failed to decode SGVs as array after trying to reauth: " + response)
                         }
                     }
-
+                    
                     var transformed: Array<ShareGlucose> = []
                     for sgv in sgvs {
                         if let glucose = sgv["Value"] as? Int, let trend = sgv["Trend"] as? Int, let wt = sgv["WT"] as? String {
@@ -191,7 +206,7 @@ public class ShareClient {
             }
         }
     }
-
+    
     private func parseDate(_ wt: String) throws -> Date {
         // wt looks like "/Date(1462404576000)/"
         let re = try NSRegularExpression(pattern: "\\((.*)\\)", options: [])

--- a/ShareClient/ShareClient.swift
+++ b/ShareClient/ShareClient.swift
@@ -47,22 +47,22 @@ private let maxReauthAttempts = 2
 // ¯\_(ツ)_/¯
 private func dexcomPOST(_ url: URL, JSONData: [String: AnyObject]? = nil, callback: @escaping (Error?, String?) -> Void) {
     var data: Data?
-    
+
     if let JSONData = JSONData {
         guard let encoded = try? JSONSerialization.data(withJSONObject: JSONData, options:[]) else {
             return callback(ShareError.dataError(reason: "Failed to encode JSON for POST to " + url.absoluteString), nil)
         }
-        
+
         data = encoded
     }
-    
+
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     request.addValue("application/json", forHTTPHeaderField: "Content-Type")
     request.addValue("application/json", forHTTPHeaderField: "Accept")
     request.addValue(dexcomUserAgent, forHTTPHeaderField: "User-Agent")
     request.httpBody = data
-    
+
     URLSession.shared.dataTask(with: request, completionHandler: { (data, response, error) in
         if error != nil {
             callback(error, nil)
@@ -75,10 +75,10 @@ private func dexcomPOST(_ url: URL, JSONData: [String: AnyObject]? = nil, callba
 public class ShareClient {
     public let username: String
     public let password: String
-    
+
     private let shareServer:String
     private var token: String?
-    
+
     public init(username: String, password: String, shareServer:ShareServer=ShareServer.US) {
         self.username = username
         self.password = password
@@ -95,7 +95,7 @@ public class ShareClient {
     public func fetchLast(_ n: Int, callback: @escaping (ShareError?, [ShareGlucose]?) -> Void) {
         fetchLastWithRetries(n, remaining: maxReauthAttempts, callback: callback)
     }
-    
+
     private func ensureToken(_ callback: @escaping (ShareError?) -> Void) {
         if token != nil {
             callback(nil)
@@ -110,30 +110,30 @@ public class ShareClient {
             }
         }
     }
-    
+
     private func fetchToken(_ callback: @escaping (ShareError?, String?) -> Void) {
         let data = [
             "accountName": username,
             "password": password,
             "applicationId": dexcomApplicationId
         ]
-        
+
         guard let url = URL(string: shareServer + dexcomLoginPath) else {
             return callback(ShareError.fetchError, nil)
         }
-        
+
         dexcomPOST(url, JSONData: data as [String : AnyObject]?) { (error, response) in
             if let error = error {
                 return callback(.httpError(error), nil)
             }
-            
+
             guard let   response = response,
                 let data = response.data(using: .utf8),
                 let decoded = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)
                 else {
                     return callback(.loginError(errorCode: "unknown"), nil)
             }
-            
+
             if let token = decoded as? String {
                 // success is a JSON-encoded string containing the token
                 callback(nil, token)
@@ -144,37 +144,37 @@ public class ShareClient {
             }
         }
     }
-    
+
     private func fetchLastWithRetries(_ n: Int, remaining: Int, callback: @escaping (ShareError?, [ShareGlucose]?) -> Void) {
         ensureToken() { (error) in
             guard error == nil else {
                 return callback(error, nil)
             }
-            
+
             guard var components = URLComponents(string: self.shareServer + dexcomLatestGlucosePath) else {
                 return callback(.fetchError, nil)
             }
-            
+
             components.queryItems = [
                 URLQueryItem(name: "sessionId", value: self.token),
                 URLQueryItem(name: "minutes", value: String(1440)),
                 URLQueryItem(name: "maxCount", value: String(n))
             ]
-            
+
             guard let url = components.url else {
                 return callback(.fetchError, nil)
             }
-            
+
             dexcomPOST(url) { (error, response) in
                 if let error = error {
                     return callback(.httpError(error), nil)
                 }
-                
+
                 do {
                     guard let response = response else {
                         throw ShareError.fetchError
                     }
-                    
+
                     let decoded = try? JSONSerialization.jsonObject(with: response.data(using: .utf8)!, options: [])
                     guard let sgvs = decoded as? Array<AnyObject> else {
                         if remaining > 0 {
@@ -184,7 +184,7 @@ public class ShareClient {
                             throw ShareError.dataError(reason: "Failed to decode SGVs as array after trying to reauth: " + response)
                         }
                     }
-                    
+
                     var transformed: Array<ShareGlucose> = []
                     for sgv in sgvs {
                         if let glucose = sgv["Value"] as? Int, let trend = sgv["Trend"] as? Int, let wt = sgv["WT"] as? String {
@@ -206,7 +206,7 @@ public class ShareClient {
             }
         }
     }
-    
+
     private func parseDate(_ wt: String) throws -> Date {
         // wt looks like "/Date(1462404576000)/"
         let re = try NSRegularExpression(pattern: "\\((.*)\\)", options: [])

--- a/ShareClient/ShareClient.swift
+++ b/ShareClient/ShareClient.swift
@@ -76,7 +76,7 @@ public class ShareClient {
     public let username: String
     public let password: String
     
-    private let shareServer:String?
+    private let shareServer:String
     private var token: String?
     
     public init(username: String, password: String, shareServer:ShareServer=ShareServer.US) {
@@ -118,7 +118,7 @@ public class ShareClient {
             "applicationId": dexcomApplicationId
         ]
         
-        guard let url = URL(string: shareServer! + dexcomLoginPath) else {
+        guard let url = URL(string: shareServer + dexcomLoginPath) else {
             return callback(ShareError.fetchError, nil)
         }
         
@@ -151,7 +151,7 @@ public class ShareClient {
                 return callback(error, nil)
             }
             
-            guard var components = URLComponents(string: self.shareServer! + dexcomLatestGlucosePath) else {
+            guard var components = URLComponents(string: self.shareServer + dexcomLatestGlucosePath) else {
                 return callback(.fetchError, nil)
             }
             


### PR DESCRIPTION
Hi.  I would really like to have support for US, NON_US and Custom Shareservers during init.

For the last case, the primary use case would be to use a custom shareserver like  my https://github.com/dabear/NightscoutShareServer .
 

Example
```swift

let client=ShareClient(username: "Foo", password: "Bar", shareServer:ShareServer.Custom("https://mockedshareserver.azurewebsites.net"))
//these are also possible:
//let client=ShareClient(username: "Foo", password: "Bar", shareServer:ShareServer.US)
//let client=ShareClient(username: "Foo", password: "Bar", shareServer:ShareServer.Non_US)
//let client=ShareClient(username: "Foo", password: "Bar") // defaults to US

//this will always return 2 glucose values, because we're using my mockedshareserver which is hardcoded to return only two (fake) values 
client.fetchLast(5) { (error, glucose) in
    print("glucose: \(glucose), error: \(error)")
}

print("done")
```